### PR TITLE
Allow UTF-8 characters in overlay_args

### DIFF
--- a/app/controllers/overlastic/concerns/overlay_handling.rb
+++ b/app/controllers/overlastic/concerns/overlay_handling.rb
@@ -30,7 +30,7 @@ module Overlastic::Concerns::OverlayHandling
       # Force render of overlays without an initiator
       request.headers["Overlay-Target"] ||= options.delete(:overlay_target)
       request.headers["Overlay-Type"] ||= options.delete(:overlay_type)
-      request.headers["Overlay-Args"] ||= options.delete(:overlay_args)&.to_json
+      request.headers["Overlay-Args"] ||= Base64.encode64(options.delete(:overlay_args).to_json) if options.key?(:overlay_args)
 
       # If renderable content other than HTML is passed we should avoid returning a stream
       avoid_stream = _renderers.excluding(:html).intersection(options.keys).present?

--- a/app/helpers/overlastic/navigation_helper.rb
+++ b/app/helpers/overlastic/navigation_helper.rb
@@ -20,7 +20,7 @@ module Overlastic::NavigationHelper
       options["data"][:overlay_target] = target if target.present?
 
       args = options.delete("overlay_args")
-      options["data"][:overlay_args] = args.to_json if args.present?
+      options["data"][:overlay_args] = Base64.encode64(args.to_json) if args.present?
 
       options["target"] = :_blank
 
@@ -42,7 +42,7 @@ module Overlastic::NavigationHelper
       html_options["data"][:overlay_target] = target if target.present?
 
       args = html_options.delete("overlay_args")
-      html_options["data"][:overlay_args] = args.to_json if args.present?
+      html_options["data"][:overlay_args] = Base64.encode64(args.to_json) if args.present?
 
       html_options["target"] = :_blank
 

--- a/app/helpers/overlastic/overlays_helper.rb
+++ b/app/helpers/overlastic/overlays_helper.rb
@@ -48,7 +48,7 @@ module Overlastic::OverlaysHelper
     string = capture(&block)
     type = request.headers["Overlay-Type"] || Overlastic.configuration.default_overlay
     args_header = request.headers["Overlay-Args"]
-    overlay_args = JSON.parse(request.headers["Overlay-Args"]) if args_header.present?
+    overlay_args = JSON.parse(Base64.decode64(request.headers["Overlay-Args"])) if args_header.present?
     locals.merge! overlay_args.to_h.symbolize_keys
 
     overlastic_tag do

--- a/test/dummy/app/views/dialogs/articles/index.html.erb
+++ b/test/dummy/app/views/dialogs/articles/index.html.erb
@@ -10,6 +10,6 @@
   <p>
     <%= link_to_overlay article.body, dialogs_article_path(article) %>
     -
-    <%= link_to_overlay "Edit", edit_dialogs_article_path(article), overlay_type: :dialog, overlay_args: { title: "Edit article" } %>
+    <%= link_to_overlay "Edit", edit_dialogs_article_path(article), overlay_type: :dialog, overlay_args: { title: "✏️ Edit article" } %>
   </p>
 <% end %>

--- a/test/helpers/navigation_helper_test.rb
+++ b/test/helpers/navigation_helper_test.rb
@@ -10,7 +10,7 @@ class Overlastic::NavigationHelperTest < ActionView::TestCase
   end
 
   test "link_to_overlay with args" do
-    assert_match 'data-overlay-args="{&quot;title&quot;:&quot;Test dialog&quot;}"', link_to_overlay("Link", new_dialogs_article_path, overlay_args: { title: "Test dialog" })
+    assert_match "data-overlay-args=\"#{Base64.encode64({ title: "Test dialog" }.to_json)}\"", link_to_overlay("Link", new_dialogs_article_path, overlay_args: { title: "Test dialog" })
   end
 
   test "link_to_overlay without explicit target" do


### PR DESCRIPTION
Using UTF-8 characters inside `overlay_args` generates different problems.

## Case #1
`link_to_overlay "Test", test_path, overlay_args: { title: "Test thís" }`

raises an `ArgumentError` with `invalid byte sequence in UTF-8`.

## Case #2
`link_to_overlay "Test", test_path, overlay_args: { title: "✏️ Test" }`

will simply behave as a non-overlay request.